### PR TITLE
Update requirement to use exifread

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -1,2 +1,2 @@
-exiftool
+exifread
 sqlite


### PR DESCRIPTION
Hi,

I was having problems installing the dependencies for this project because `exiftool` was specified in the requirements instead of the package used `exifread`.

```
Collecting exiftool (from -r requirement.txt (line 1))
  Could not find a version that satisfies the requirement exiftool (from -r requirement.txt (line 1)) (from versions: )
No matching distribution found for exiftool (from -r requirement.txt (line 1))
```

This pull request updates the requirements to use `exifread`.

Thanks,
Rob